### PR TITLE
Use empty interface as _id property

### DIFF
--- a/cascade_test.go
+++ b/cascade_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Parent struct {
-	DocumentBase `bson:",inline"`
-	Bar          string
-	Number       int
-	FooBar       string
-	Children     []ChildRef
-	Child        ChildRef
-	ChildProp    string `bson:"childProp"`
-	diffTracker  *DiffTracker
+	DocumentBase       `bson:",inline"`
+	Bar         string
+	Number      int
+	FooBar      string
+	Children    []ChildRef
+	Child       ChildRef
+	ChildProp   string `bson:"childProp"`
+	diffTracker *DiffTracker
 }
 
 func (f *Parent) GetDiffTracker() *DiffTracker {
@@ -29,12 +29,12 @@ func (f *Parent) GetDiffTracker() *DiffTracker {
 }
 
 type Child struct {
-	DocumentBase `bson:",inline"`
-	ParentId     bson.ObjectId `bson:",omitempty"`
-	Name         string
-	SubChild     SubChildRef `bson:"subChild"`
-	ChildProp    string
-	diffTracker  *DiffTracker
+	DocumentBase            `bson:",inline"`
+	ParentId    interface{} `bson:",omitempty"`
+	Name        string
+	SubChild    SubChildRef `bson:"subChild"`
+	ChildProp   string
+	diffTracker *DiffTracker
 }
 
 func (c *Child) GetCascade(collection *Collection) []*CascadeConfig {
@@ -107,8 +107,8 @@ func (f *Child) GetDiffTracker() *DiffTracker {
 
 type SubChild struct {
 	DocumentBase `bson:",inline"`
-	Foo          string
-	ChildId      bson.ObjectId
+	Foo     string
+	ChildId interface{}
 }
 
 func (c *SubChild) GetCascade(collection *Collection) []*CascadeConfig {
@@ -134,12 +134,12 @@ func (c *SubChild) GetCascade(collection *Collection) []*CascadeConfig {
 }
 
 type SubChildRef struct {
-	Id  bson.ObjectId `bson:"_id,omitempty"`
+	Id  interface{} `bson:"_id,omitempty"`
 	Foo string
 }
 
 type ChildRef struct {
-	Id       bson.ObjectId `bson:"_id,omitempty"`
+	Id       interface{} `bson:"_id,omitempty"`
 	Name     string
 	SubChild SubChildRef
 }
@@ -186,9 +186,9 @@ func TestCascade(t *testing.T) {
 		collection.FindById(parent.Id, newParent)
 
 		So(newParent.Child.Name, ShouldEqual, "Foo McGoo")
-		So(newParent.Child.Id.Hex(), ShouldEqual, child.Id.Hex())
+		So(newParent.Child.Id, ShouldEqual, child.Id)
 		So(newParent.Children[0].Name, ShouldEqual, "Foo McGoo")
-		So(newParent.Children[0].Id.Hex(), ShouldEqual, child.Id.Hex())
+		So(newParent.Children[0].Id, ShouldEqual, child.Id)
 
 		// No through prop should populate directly o the parent
 		So(newParent.ChildProp, ShouldEqual, "Doop McGoop")
@@ -216,9 +216,9 @@ func TestCascade(t *testing.T) {
 		collection.FindById(parent2.Id, newParent2)
 		So(newParent2.ChildProp, ShouldEqual, "Doop McGoop")
 		So(newParent2.Child.Name, ShouldEqual, "Foo McGoo")
-		So(newParent2.Child.Id.Hex(), ShouldEqual, child.Id.Hex())
+		So(newParent2.Child.Id, ShouldEqual, child.Id)
 		So(newParent2.Children[0].Name, ShouldEqual, "Foo McGoo")
-		So(newParent2.Children[0].Id.Hex(), ShouldEqual, child.Id.Hex())
+		So(newParent2.Children[0].Id, ShouldEqual, child.Id)
 
 		// Make a new sub child, save it, and it should cascade to the child AND the parent
 		subChild := &SubChild{
@@ -236,7 +236,7 @@ func TestCascade(t *testing.T) {
 		newParent3 := &Parent{}
 		collection.FindById(parent2.Id, newParent3)
 		So(newParent3.Child.SubChild.Foo, ShouldEqual, "MySubChild")
-		So(newParent3.Child.SubChild.Id.Hex(), ShouldEqual, subChild.Id.Hex())
+		So(newParent3.Child.SubChild.Id, ShouldEqual, subChild.Id)
 
 		newParent4 := &Parent{}
 		err = childCollection.DeleteDocument(child)

--- a/documentBase.go
+++ b/documentBase.go
@@ -1,14 +1,17 @@
 package bongo
 
 import (
-	"github.com/globalsign/mgo/bson"
 	"time"
 )
 
+type Validater interface {
+	Valid() bool
+}
+
 type DocumentBase struct {
-	Id       bson.ObjectId `bson:"_id,omitempty" json:"_id"`
-	Created  *time.Time     `bson:"_created" json:"_created"`
-	Modified *time.Time     `bson:"_modified" json:"_modified"`
+	Id       interface{} `bson:"_id,omitempty" json:"_id"`
+	Created  *time.Time  `bson:"_created" json:"_created"`
+	Modified *time.Time  `bson:"_modified" json:"_modified"`
 
 	// We want this to default to false without any work. So this will be the opposite of isNew. We want it to be new unless set to existing
 	exists bool
@@ -25,12 +28,12 @@ func (d *DocumentBase) IsNew() bool {
 }
 
 // Satisfy the document interface
-func (d *DocumentBase) GetId() bson.ObjectId {
+func (d *DocumentBase) GetId() interface{} {
 	return d.Id
 }
 
 // Sets the ID for the document
-func (d *DocumentBase) SetId(id bson.ObjectId) {
+func (d *DocumentBase) SetId(id interface{}) {
 	d.Id = id
 }
 

--- a/validate.go
+++ b/validate.go
@@ -10,7 +10,7 @@ func ValidateRequired(val interface{}) bool {
 	return valueOf.Interface() != reflect.Zero(valueOf.Type()).Interface()
 }
 
-func ValidateMongoIdRef(id bson.ObjectId, collection *Collection) bool {
+func ValidateMongoIdRef(id interface{}, collection *Collection) bool {
 	count, err := collection.Collection().Find(bson.M{"_id": id}).Count()
 
 	if err != nil || count <= 0 {


### PR DESCRIPTION
Bongo library uses objectId as a primary key and does not allow to change it. I've replaced an objectId type with an empty interface.