### PR TITLE
Omit empty timestamps

### DIFF
--- a/documentBase.go
+++ b/documentBase.go
@@ -10,8 +10,8 @@ type Validater interface {
 
 type DocumentBase struct {
 	Id       interface{} `bson:"_id,omitempty" json:"_id"`
-	Created  *time.Time  `bson:"_created" json:"_created"`
-	Modified *time.Time  `bson:"_modified" json:"_modified"`
+	Created  *time.Time  `bson:"_created,omitempty" json:"_created,omitempty"`
+	Modified *time.Time  `bson:"_modified,omitempty" json:"_modified,omitempty"`
 
 	// We want this to default to false without any work. So this will be the opposite of isNew. We want it to be new unless set to existing
 	exists bool


### PR DESCRIPTION
These lines should be there. Otherwise, timestamps are marshaling as «null» values. 